### PR TITLE
primary key for usstates

### DIFF
--- a/northwind.sql
+++ b/northwind.sql
@@ -3806,6 +3806,14 @@ ALTER TABLE ONLY territories
 
 
 --
+-- Name: pk_usstates; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY usstates
+    ADD CONSTRAINT pk_usstates PRIMARY KEY (stateid);
+
+
+--
 -- Name: fk_orders_customers; Type: Constraint; Schema: -; Owner: -
 --
 


### PR DESCRIPTION
By adding this primary key CONSTAINT for ussstates becomes fully avaliable to use at EF Core 2.0 Scaffold-DbContext:

Scaffold-DbContext "Host=localhost;Database=northwind;Username=northwind_user;Password=thewindisblowing;Persist Security Info=True" Npgsql.EntityFrameworkCore.PostgreSQL -OutputDir Models -Verbose