### PR TITLE
Added windows compose file and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,31 @@ Use the provided sql file `nortwhind.sql` in order to populate your database.
 
 #### 1. run docker-compose
 
-On Windows you need to do this:
+**NOTE:** On Windows you need to do this first:
 ```
 docker volume create --name northwind-pg-data -d local
 ```
+If you're using Windows, you also need to make sure the volume being referenced is the one you just created.  The `docker-compose-windows.yml` file does this AND also exposes port 5432 so that external processes can access the database as well.
+
 
 Then just do this:
 
-```bash
+```bash 
 > docker-compose up
+```
 
+**NOTE:** Simply doing `docker-compose up` will enable you to interact as shown below (with another Docker process), but if you want to interact from a non-Docker process on the host (like VS Code, or some application that you would like to write outside of Docker), you should expose port 5432
+or another one of your choosing as shown in `docker-compose-windows.yml`.  
+
+To use the `docker-windows.yml` version which *exposes port 5432 and uses the volume created above*, just do this:
+
+```
+docker-compose -f .\docker-compose-windows.yml up
+```
+
+After running either of the above `docker-compose` commands, you should see some output in the terminal:
+
+```
 ...
 ... Lots of messages...
 ...
@@ -64,10 +79,10 @@ postgres=# select * from us_states;
 ````
 
 ##### Option 2: Connect via application or other means
-Server: localhost
-Port: 5432
-Database: northwind
-User: northwind_user
+* Server: localhost
+* Port: 5432
+* Database: northwind
+* User: northwind_user
 
 
 #### 3. stop docker-compose

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ db_1  | 2019-11-28 21:07:14.364 UTC [1] LOG:  listening on Unix socket "/var/run
 db_1  | 2019-11-28 21:07:14.474 UTC [1] LOG:  database system is ready to accept connections
 ```
 
-#### 2. run psql client in the docker-compose container
+#### 2. Connect to the database and interact!
+
+##### Option 1: Run psql client in the docker-compose container
 
 Open another terminal window, and type:
 
@@ -60,6 +62,13 @@ postgres=# select * from us_states;
         2 | Alaska               | AK         | north
         ...
 ````
+
+##### Option 2: Connect via application or other means
+Server: localhost
+Port: 5432
+Database: northwind
+User: northwind_user
+
 
 #### 3. stop docker-compose
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Use the provided sql file `nortwhind.sql` in order to populate your database.
 
 #### 1. run docker-compose
 
+On Windows you need to do this:
+```
+docker volume create --name northwind-pg-data -d local
+```
+
+Then just do this:
+
 ```bash
 > docker-compose up
 

--- a/docker-compose-windows.yml
+++ b/docker-compose-windows.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+services:
+  db:
+    image: postgres:12
+    environment:
+      POSTGRES_DB: northwind
+      POSTGRES_USER: northwind_user
+      POSTGRES_PASSWORD: thewindisblowing
+    volumes:
+      - northwind-pg-data:/var/lib/postgresql/data
+      - ./northwind.sql:/docker-entrypoint-initdb.d/northwind.sql
+    ports:
+      - "5432:5432"
+
+volumes:
+  northwind-pg-data:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,5 @@ services:
       POSTGRES_USER: northwind_user
       POSTGRES_PASSWORD: thewindisblowing
     volumes:
-      - northwind-pg-data:/var/lib/postgresql/data
+      - ./dbdata:/var/lib/postgresql/data
       - ./northwind.sql:/docker-entrypoint-initdb.d/northwind.sql
-    ports:
-      - "5432:5432"
-
-volumes:
-  northwind-pg-data:
-    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,11 @@ services:
       POSTGRES_USER: northwind_user
       POSTGRES_PASSWORD: thewindisblowing
     volumes:
-      - ./dbdata:/var/lib/postgresql/data
+      - northwind-pg-data:/var/lib/postgresql/data
       - ./northwind.sql:/docker-entrypoint-initdb.d/northwind.sql
+    ports:
+      - "5432:5432"
+
+volumes:
+  northwind-pg-data:
+    external: true


### PR DESCRIPTION
The windows compose file has two features: it uses an external volume so that things work on Windows, and it exposes port 5432.  This enables developers to interact with the running container outside of Docker (I'm creating an ASP.NET Core API project and not using containers for it at the moment).

I can also explore the data from VS Code, which is a nice added bonus.