### PR TITLE
Adding pgAdmin working directory to the volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     volumes:
       - postgresql_bin:/usr/lib/postgresql
       - pgadmin_root_prefs:/root/.pgadmin
+      - pgadmin_working_dir:/var/lib/pgadmin
       - ./files:/files
     ports:
       - 5050:5050
@@ -41,6 +42,8 @@ networks:
 
 volumes:
   pgadmin_root_prefs:
+    driver: local
+  pgadmin_working_dir:
     driver: local
   postgresql_data:
     driver: local


### PR DESCRIPTION
[/var/lib/pgadmin](https://www.pgadmin.org/docs/pgadmin4/development/container_deployment.html)

This is the working directory in which pgAdmin stores session data, user files, configuration files, and it’s configuration database. Mapping this directory onto the host machine gives you an easy way to maintain configuration between invocations of the container.