### PR TITLE
"version" is obsolette and has been removed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     container_name: db


### PR DESCRIPTION
The top-level [version property](https://docs.docker.com/reference/compose-file/version-and-name/) is defined by the Compose Specification for backward compatibility. It is only informative and you'll receive a warning message that it is obsolete if used.